### PR TITLE
chore: use boolean parser from plugin-user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/kit",
-  "version": "1.5.17",
+  "version": "1.5.18",
   "description": "Commonly needed utilities for TypeScript and JavaScript",
   "main": "lib/index.js",
   "repository": "forcedotcom/kit",

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,7 +7,7 @@
 
 import { definiteEntriesOf, Dictionary, isKeyOf, KeyValue, Nullable, Optional, isNumber } from '@salesforce/ts-types';
 import { InvalidDefaultEnvValueError } from './errors';
-import { toNumber } from './nodash';
+import { toNumber, toBoolean } from './nodash';
 
 /**
  * An injectable abstraction on top of `process.env` with various convenience functions
@@ -208,14 +208,7 @@ export class Env {
    */
   public getBoolean(key: string, def = false): boolean {
     const value = this.getString(key, def.toString());
-    switch (typeof value) {
-      case 'boolean':
-        return value;
-      case 'string':
-        return value.toLowerCase() === 'true' || value === '1';
-      default:
-        return false;
-    }
+    return toBoolean(value);
   }
 
   /**

--- a/src/env.ts
+++ b/src/env.ts
@@ -208,7 +208,14 @@ export class Env {
    */
   public getBoolean(key: string, def = false): boolean {
     const value = this.getString(key, def.toString());
-    return value.toLowerCase() === 'true' || value === '1';
+    switch (typeof value) {
+      case 'boolean':
+        return value;
+      case 'string':
+        return value.toLowerCase() === 'true' || value === '1';
+      default:
+        return false;
+    }
   }
 
   /**

--- a/src/nodash/internal.ts
+++ b/src/nodash/internal.ts
@@ -84,3 +84,20 @@ export function upperFirst(value?: string): Optional<string>;
 export function upperFirst(value?: string): Optional<string> {
   return value && value.charAt(0).toUpperCase() + value.slice(1);
 }
+
+/**
+ * Converts value to a boolean.
+ *
+ * @param value The value to convert
+ * @returns boolean
+ */
+export function toBoolean(value: unknown): boolean {
+  switch (typeof value) {
+    case 'boolean':
+      return value;
+    case 'string':
+      return value.toLowerCase() === 'true' || value === '1';
+    default:
+      return false;
+  }
+}

--- a/test/nodash/internal.test.ts
+++ b/test/nodash/internal.test.ts
@@ -104,4 +104,15 @@ describe('nodash internal', () => {
       expect(result).to.equal('Foo Bar');
     });
   });
+
+  describe('toBoolean', () => {
+    it('should return true given a string set to 1', () => {
+      expect(_.toBoolean('1')).to.equal(true);
+    });
+
+    it('should return false given any string that is not 1 or a boolean value', () => {
+      expect(_.toBoolean('0')).to.equal(false);
+      expect(_.toBoolean('sfdx')).to.equal(false);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,13 +645,6 @@
     "@typescript-eslint/typescript-estree" "4.32.0"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.0.tgz#9be33aed4e9901db753803ba233b70d79a87fc3e"
-  dependencies:
-    "@typescript-eslint/types" "4.31.0"
-    "@typescript-eslint/visitor-keys" "4.31.0"
-
 "@typescript-eslint/scope-manager@4.32.0":
   version "4.32.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.32.0.tgz#e03c8668f8b954072b3f944d5b799c0c9225a7d5"
@@ -659,25 +652,9 @@
     "@typescript-eslint/types" "4.32.0"
     "@typescript-eslint/visitor-keys" "4.32.0"
 
-"@typescript-eslint/types@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.0.tgz#9a7c86fcc1620189567dc4e46cad7efa07ee8dce"
-
 "@typescript-eslint/types@4.32.0":
   version "4.32.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.32.0.tgz#52c633c18da47aee09449144bf59565ab36df00d"
-
-"@typescript-eslint/typescript-estree@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.0.tgz#4da4cb6274a7ef3b21d53f9e7147cc76f278a078"
-  dependencies:
-    "@typescript-eslint/types" "4.31.0"
-    "@typescript-eslint/visitor-keys" "4.31.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.32.0":
   version "4.32.0"
@@ -690,13 +667,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.31.0":
-  version "4.31.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.0.tgz#4e87b7761cb4e0e627dc2047021aa693fc76ea2b"
-  dependencies:
-    "@typescript-eslint/types" "4.31.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.32.0":
   version "4.32.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,6 +645,13 @@
     "@typescript-eslint/typescript-estree" "4.32.0"
     debug "^4.3.1"
 
+"@typescript-eslint/scope-manager@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.0.tgz#9be33aed4e9901db753803ba233b70d79a87fc3e"
+  dependencies:
+    "@typescript-eslint/types" "4.31.0"
+    "@typescript-eslint/visitor-keys" "4.31.0"
+
 "@typescript-eslint/scope-manager@4.32.0":
   version "4.32.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.32.0.tgz#e03c8668f8b954072b3f944d5b799c0c9225a7d5"
@@ -652,9 +659,25 @@
     "@typescript-eslint/types" "4.32.0"
     "@typescript-eslint/visitor-keys" "4.32.0"
 
+"@typescript-eslint/types@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.0.tgz#9a7c86fcc1620189567dc4e46cad7efa07ee8dce"
+
 "@typescript-eslint/types@4.32.0":
   version "4.32.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.32.0.tgz#52c633c18da47aee09449144bf59565ab36df00d"
+
+"@typescript-eslint/typescript-estree@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.0.tgz#4da4cb6274a7ef3b21d53f9e7147cc76f278a078"
+  dependencies:
+    "@typescript-eslint/types" "4.31.0"
+    "@typescript-eslint/visitor-keys" "4.31.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.32.0":
   version "4.32.0"
@@ -667,6 +690,13 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@4.31.0":
+  version "4.31.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.0.tgz#4e87b7761cb4e0e627dc2047021aa693fc76ea2b"
+  dependencies:
+    "@typescript-eslint/types" "4.31.0"
+    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.32.0":
   version "4.32.0"


### PR DESCRIPTION
### What does this PR do?
Replaces current boolean parser in `Env` with the one [used in plugin-user](https://github.com/salesforcecli/plugin-user/blob/12018a6ad1c62f38fb60be3a4c8304fe14b9b503/src/commands/force/user/create.ts#L45).
Force `1.5.18` release.

### What issues does this PR fix or reference?
@W-8865618@