### PR TITLE
feat: add throttled promise class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export * from './errors';
 export * from './json';
 export * from './nodash';
 export * from './collections';
+export * from './throttledPromiseAll';

--- a/src/throttledPromiseAll.ts
+++ b/src/throttledPromiseAll.ts
@@ -35,9 +35,9 @@ export type PromiseItem<T, O = T | undefined> = {
  * ```
  */
 export class ThrottledPromiseAll<T, O = T> {
+  readonly #results: Array<O | undefined> = [];
   private readonly queue: Array<PromiseItem<T, O | undefined>>;
   private readonly concurrency: number;
-  private results: Array<O | undefined> = [];
   private wait: Duration;
   private timeout: NodeJS.Timeout | undefined;
 
@@ -50,6 +50,13 @@ export class ThrottledPromiseAll<T, O = T> {
     this.queue = [];
     this.concurrency = options.concurrency;
     this.wait = options.timeout ?? Duration.milliseconds(0);
+  }
+
+  /**
+   * Returns the results of the promises that have been resolved.
+   */
+  public get results(): Array<O | undefined> {
+    return this.#results;
   }
 
   /**
@@ -100,18 +107,11 @@ export class ThrottledPromiseAll<T, O = T> {
         await this.dequeue();
       }
       this.stop();
-      return this.results;
+      return this.#results;
     } catch (e) {
       this.stop();
       throw e;
     }
-  }
-
-  /**
-   * Returns the results of the promises that have been resolved.
-   */
-  public getResults(): Array<O | undefined> {
-    return this.results;
   }
 
   private stop(): void {
@@ -127,7 +127,7 @@ export class ThrottledPromiseAll<T, O = T> {
       const results = await Promise.all(
         next.map((item) => item.producer(item.source, this).catch((e) => Promise.reject(e)))
       );
-      this.results.push(...results);
+      this.#results.push(...results);
     }
   }
 }

--- a/src/throttledPromiseAll.ts
+++ b/src/throttledPromiseAll.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ensureArray } from './collections';
+import { Duration } from './duration';
+
+export type PromiseOptions = {
+  concurrency: number;
+  stopOnError?: boolean;
+  timeout?: Duration;
+};
+
+export type PromiseItem<T, O = T | undefined> = {
+  source: T;
+  producer: (source: T, throttledPromise: ThrottledPromiseAll<T, O | undefined>) => Promise<O | undefined>;
+};
+
+/**
+ * A promise that throttles the number of promises running at a time.
+ *
+ * The constructor takes {@link PromiseOptions} to initialize the constraints of the promise.
+ *
+ * ```typescript
+ * // Create a ThrottledPromiseAll that will take numbers and return numbers
+ * const throttledPromise = new ThrottledPromiseAll<number, number>({ concurrency: 1, timeout: Duration.milliseconds(100) });
+ *
+ * // Define a producer function that will take a number and return a promise that resolves to a number
+ * const numberProducer = (source: number, throttledPromiseAll: ThrottledPromiseAll<number, number | undefined>): Promise<number> => Promise.resolve(source + 1);
+ * throttledPromiseAll.add([1, 2, 3, 4, 5], numberProducer);
+ *
+ * const numberResults = await throttledPromiseAll.all();
+ * ```
+ */
+export class ThrottledPromiseAll<T, O = T> {
+  private readonly queue: Array<PromiseItem<T, O | undefined>>;
+  private readonly concurrency: number;
+  private results: Array<O | undefined> = [];
+  private wait: Duration;
+  private timeout: NodeJS.Timeout | undefined;
+
+  /**
+   * Construct a new ThrottledPromiseAll.
+   *
+   * @param options {@link PromiseOptions}
+   */
+  public constructor(options: PromiseOptions = { concurrency: 1 }) {
+    this.queue = [];
+    this.concurrency = options.concurrency;
+    this.wait = options.timeout ?? Duration.milliseconds(0);
+  }
+
+  /**
+   * Add source items to the queue of promises to be resolved.
+   * Adding an item to the queue requires a producer function that will take the source item and return a promise.
+   * Each item in the can have a different producer function, as long as the producer function conforms the
+   * types of the ThrottledPromiseAll when constructed.
+   *
+   * @param source
+   * @param producer the producer function that will take the source item and return a promise. The producer function signature
+   * must conform to the types of the ThrottledPromiseAll when constructed.
+   */
+  public add(
+    source: T | T[],
+    producer: (source: T, throttledPromise: ThrottledPromiseAll<T, O | undefined>) => Promise<O | undefined>
+  ): void {
+    ensureArray(source).forEach((s) => this.queue.push({ source: s, producer }));
+  }
+
+  /**
+   * Returns a promise that resolves the items present in the queue using the associated producer.
+   *
+   * This function will throw an error if the timeout is reached before all items in the queue are resolved (see {@link PromiseOptions.timeout}).
+   *
+   * @returns A promise that resolves to an array of results.
+   */
+  public async all(): Promise<Array<O | undefined>> {
+    let timeoutPromise: Promise<void> | undefined;
+    if (this.wait.milliseconds > 0) {
+      if (!this.timeout) {
+        timeoutPromise = new Promise((resolve, reject) => {
+          this.timeout = setTimeout(() => {
+            try {
+              clearTimeout(this.timeout);
+              this.stop();
+              reject(new Error(`PromiseQueue timed out after ${this.wait.milliseconds} milliseconds`));
+            } catch (e) {
+              reject(e);
+            }
+          }, this.wait.milliseconds);
+        });
+      }
+    }
+    try {
+      if (timeoutPromise) {
+        await Promise.race([this.dequeue(), timeoutPromise]);
+      } else {
+        await this.dequeue();
+      }
+      this.stop();
+      return this.results;
+    } catch (e) {
+      this.stop();
+      throw e;
+    }
+  }
+
+  /**
+   * Returns the results of the promises that have been resolved.
+   */
+  public getResults(): Array<O | undefined> {
+    return this.results;
+  }
+
+  private stop(): void {
+    clearTimeout(this.timeout);
+    this.queue.splice(0, this.queue.length);
+  }
+
+  private async dequeue(): Promise<void> {
+    while (this.queue.length > 0) {
+      const next = this.queue.slice(0, this.concurrency);
+      this.queue.splice(0, this.concurrency);
+      // eslint-disable-next-line no-await-in-loop
+      const results = await Promise.all(
+        next.map((item) => item.producer(item.source, this).catch((e) => Promise.reject(e)))
+      );
+      this.results.push(...results);
+    }
+  }
+}

--- a/test/promiseQueue.test.ts
+++ b/test/promiseQueue.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import { ThrottledPromiseAll } from '../src/throttledPromiseAll';
+import { Duration } from '../src/duration';
+
+describe('throttledPromiseAll', () => {
+  const numberProducer = (
+    source: number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    throttledPromise: ThrottledPromiseAll<number, number | undefined>
+  ): Promise<number> => Promise.resolve(source + 1);
+
+  it('should execute promises in order', async () => {
+    const throttledPromiseAll: ThrottledPromiseAll<number, number> = new ThrottledPromiseAll({ concurrency: 1 });
+    for (const i of [1, 2, 3, 4, 5]) {
+      // eslint-disable-next-line no-await-in-loop
+      throttledPromiseAll.add(i, numberProducer);
+    }
+    await throttledPromiseAll.all();
+    const results = throttledPromiseAll.getResults() as number[];
+    expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
+  });
+  it('should execute promises in groups of 2 - auto start', async () => {
+    const throttledPromiseAll: ThrottledPromiseAll<number, number> = new ThrottledPromiseAll({ concurrency: 2 });
+    for (const i of [1, 2, 3, 4, 5]) {
+      // eslint-disable-next-line no-await-in-loop
+      throttledPromiseAll.add(i, numberProducer);
+    }
+    await throttledPromiseAll.all();
+    const results = throttledPromiseAll.getResults() as number[];
+    expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
+  });
+  it('should execute promises in groups of 10 - auto start', async () => {
+    const throttledPromiseAll: ThrottledPromiseAll<number, number> = new ThrottledPromiseAll({ concurrency: 10 });
+    for (const i of [1, 2, 3, 4, 5]) {
+      // eslint-disable-next-line no-await-in-loop
+      throttledPromiseAll.add(i, numberProducer);
+    }
+    await throttledPromiseAll.all();
+    const results = throttledPromiseAll.getResults() as number[];
+    expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
+  });
+  it('should should reject', async () => {
+    try {
+      const throttledPromiseAll: ThrottledPromiseAll<number, number> = new ThrottledPromiseAll({
+        concurrency: 1,
+        timeout: Duration.milliseconds(5000),
+      });
+      throttledPromiseAll.add([1], (source) => Promise.reject(new Error(`Promise ${source} rejected`)));
+      await throttledPromiseAll.all();
+    } catch (e) {
+      expect((e as Error).message).to.equal('Promise 1 rejected');
+    }
+  });
+  it('should should timeout', async () => {
+    try {
+      const throttledPromiseAll: ThrottledPromiseAll<number, number> = new ThrottledPromiseAll({
+        concurrency: 1,
+        timeout: Duration.milliseconds(100),
+      });
+      throttledPromiseAll.add(
+        [1, 2, 3, 4, 5],
+        (source) => new Promise((resolve) => setTimeout(() => resolve(source + 1), 10000))
+      );
+      await throttledPromiseAll.all();
+    } catch (e) {
+      expect((e as Error).message).to.equal('PromiseQueue timed out after 100 milliseconds');
+    }
+  });
+  it('should add more to the queue', async () => {
+    const throttledPromiseAll: ThrottledPromiseAll<number, number> = new ThrottledPromiseAll({ concurrency: 1 });
+    throttledPromiseAll.add(
+      1,
+      (source: number, throttledPromise: ThrottledPromiseAll<number, number | undefined>): Promise<number> => {
+        if (source === 1) {
+          throttledPromise.add([2, 3, 4, 5], numberProducer);
+        }
+        return Promise.resolve(source + 1);
+      }
+    );
+    await throttledPromiseAll.all();
+    const results = throttledPromiseAll.getResults() as number[];
+    expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
+  });
+});

--- a/test/promiseQueue.test.ts
+++ b/test/promiseQueue.test.ts
@@ -22,7 +22,7 @@ describe('throttledPromiseAll', () => {
       throttledPromiseAll.add(i, numberProducer);
     }
     await throttledPromiseAll.all();
-    const results = throttledPromiseAll.getResults() as number[];
+    const results = throttledPromiseAll.results as number[];
     expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
   });
   it('should execute promises in groups of 2 - auto start', async () => {
@@ -32,7 +32,7 @@ describe('throttledPromiseAll', () => {
       throttledPromiseAll.add(i, numberProducer);
     }
     await throttledPromiseAll.all();
-    const results = throttledPromiseAll.getResults() as number[];
+    const results = throttledPromiseAll.results as number[];
     expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
   });
   it('should execute promises in groups of 10 - auto start', async () => {
@@ -42,7 +42,7 @@ describe('throttledPromiseAll', () => {
       throttledPromiseAll.add(i, numberProducer);
     }
     await throttledPromiseAll.all();
-    const results = throttledPromiseAll.getResults() as number[];
+    const results = throttledPromiseAll.results as number[];
     expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
   });
   it('should reject', async () => {
@@ -84,7 +84,7 @@ describe('throttledPromiseAll', () => {
       }
     );
     await throttledPromiseAll.all();
-    const results = throttledPromiseAll.getResults() as number[];
+    const results = throttledPromiseAll.results as number[];
     expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
   });
 });

--- a/test/promiseQueue.test.ts
+++ b/test/promiseQueue.test.ts
@@ -45,7 +45,7 @@ describe('throttledPromiseAll', () => {
     const results = throttledPromiseAll.getResults() as number[];
     expect(results).to.deep.equal([1, 2, 3, 4, 5].map((i) => i + 1));
   });
-  it('should should reject', async () => {
+  it('should reject', async () => {
     try {
       const throttledPromiseAll: ThrottledPromiseAll<number, number> = new ThrottledPromiseAll({
         concurrency: 1,
@@ -57,7 +57,7 @@ describe('throttledPromiseAll', () => {
       expect((e as Error).message).to.equal('Promise 1 rejected');
     }
   });
-  it('should should timeout', async () => {
+  it('should timeout', async () => {
     try {
       const throttledPromiseAll: ThrottledPromiseAll<number, number> = new ThrottledPromiseAll({
         concurrency: 1,


### PR DESCRIPTION
@W-11940230@
```
/**
 * A promise that throttles the number of promises running at a time.
 *
 * The constructor takes {@link PromiseOptions} to initialize the constraints of the promise.
 *
 * ```typescript
 * // Create a ThrottledPromiseAll that will take numbers and return numbers
 * const throttledPromise = new ThrottledPromiseAll<number, number>({ concurrency: 1, timeout: Duration.milliseconds(100) });
 *
 * // Define a producer function that will take a number and return a promise that resolves to a number
 * const numberProducer = (source: number, throttledPromiseAll: ThrottledPromiseAll<number, number | undefined>): Promise<number> => Promise.resolve(source + 1);
 * throttledPromiseAll.add([1, 2, 3, 4, 5], numberProducer);
 *
 * const numberResults = await throttledPromiseAll.all();
 * ```
 */
```