### PR TITLE
fix: getNumber, if given a default, guarantees the return type is of type number

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -231,7 +231,9 @@ export class Env {
    * @param key The name of the envar.
    * @param def A default number, which itself defaults to `undefined` if not otherwise supplied.
    */
-  public getNumber(key: string, def?: number): Optional<number> {
+  public getNumber(key: string, def: number): number;
+  public getNumber(key: string, def?: undefined): Optional<number>;
+  public getNumber(key: string, def?: number | undefined): Optional<number> {
     const value = this.getString(key);
     if (value) {
       const num = toNumber(value);

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -186,6 +186,7 @@ describe('Env', () => {
 
   it('should get NaN for invalid numbers', () => {
     env.setString('NUM6', 'invalid');
+    // casing because we know it's the string 'invalid'
     expect(isNaN(env.getNumber('NUM6') as number)).to.be.true;
   });
 


### PR DESCRIPTION
overloads so that 
getNumber, if given a default, guarantees the return type is of type number


### before

![Screen Shot 2023-01-03 at 10 29 35 AM](https://user-images.githubusercontent.com/4261788/210399218-6ef559bb-f4b9-4893-a81a-8327ff6dee90.png)


### after
![Screen Shot 2023-01-03 at 10 31 57 AM](https://user-images.githubusercontent.com/4261788/210399609-5267e4e8-de2d-4899-a0bd-7396b59488e8.png)



