### PR TITLE
feat: add settleAll with types

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2022, Salesforce.com, Inc.
+Copyright (c) 2023, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,4 @@ export * from './json';
 export * from './nodash';
 export * from './collections';
 export * from './throttledPromiseAll';
+export * from './settleAll';

--- a/src/settleAll.ts
+++ b/src/settleAll.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export type SettledResult<T, E = Error> = {
+  fulfilled: T[];
+  rejected: E[];
+};
+
+export async function settleAll<T, E = Error>(promises: Array<Promise<T>>): Promise<SettledResult<T, E>> {
+  const settled: SettledResult<T, E> = {
+    fulfilled: [],
+    rejected: [],
+  };
+
+  const allSettled = await Promise.allSettled(promises);
+  settled.fulfilled = allSettled
+    .filter((s) => s.status === 'fulfilled')
+    .map((s) => {
+      if (s.status === 'fulfilled') {
+        return s.value as T;
+      } else {
+        return undefined;
+      }
+    })
+    .filter((v) => v !== undefined) as T[];
+
+  settled.rejected = allSettled
+    .filter((s) => s.status === 'rejected')
+    .map((s) => {
+      if (s.status === 'rejected') {
+        return s.reason as E;
+      } else {
+        return undefined;
+      }
+    })
+    .filter((v) => v !== undefined) as E[];
+
+  return settled;
+}

--- a/test/settleAll.test.ts
+++ b/test/settleAll.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from 'chai';
+import { settleAll } from '../src';
+
+describe('settleAll', () => {
+  it('should fulfill all promises', async () => {
+    const promises = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+    const settled = await settleAll(promises);
+    expect(settled.fulfilled).to.deep.equal([1, 2, 3]);
+    expect(settled.rejected).to.deep.equal([]);
+  });
+  it('should reject all promises', async () => {
+    const promises = [Promise.reject(1), Promise.reject(2), Promise.reject(3)];
+    const settled = await settleAll(promises);
+    expect(settled.fulfilled).to.deep.equal([]);
+    expect(settled.rejected).to.deep.equal([1, 2, 3]);
+  });
+  it('should fulfill and reject promises', async () => {
+    const promises = [Promise.resolve(1), Promise.reject(2), Promise.resolve(3)];
+    const settled = await settleAll(promises);
+    expect(settled.fulfilled).to.deep.equal([1, 3]);
+    expect(settled.rejected).to.deep.equal([2]);
+  });
+  it('should handle empty array', async () => {
+    const promises: Array<Promise<never>> = [];
+    const settled = await settleAll(promises);
+    expect(settled.fulfilled).to.deep.equal([]);
+    expect(settled.rejected).to.deep.equal([]);
+  });
+  // types other than primitives
+  it('should handle types other than primitives', async () => {
+    const promises = [Promise.resolve({ a: 1 }), Promise.resolve({ b: 2 }), Promise.resolve({ c: 3 })];
+    const settled = await settleAll<Record<string, number>>(promises);
+    expect(settled.fulfilled).to.deep.equal([{ a: 1 }, { b: 2 }, { c: 3 }]);
+    expect(settled.rejected).to.deep.equal([]);
+  });
+  it('should handle types other than primitives and reject', async () => {
+    const promises = [Promise.resolve({ a: 1 }), Promise.reject(new Error('boo')), Promise.resolve({ c: 3 })];
+    const settled = await settleAll<Record<string, number>>(promises);
+    expect(settled.fulfilled).to.deep.equal([{ a: 1 }, { c: 3 }]);
+    expect(settled.rejected[0].message).to.deep.equal('boo');
+  });
+});


### PR DESCRIPTION
@W-12128179@

Add util settleAll which accepts an array of promises, wait for all to settle (Promise.settleAll) and then map results to a result with fullfilled and rejects properly isolated and typed.

```
   const promises = [Promise.resolve({ a: 1 }), Promise.reject(new Error('boo')), Promise.resolve({ c: 3 })];
    const settled = await settleAll<Record<string, number>>(promises);
    expect(settled.fulfilled).to.deep.equal([{ a: 1 }, { c: 3 }]);
    expect(settled.rejected[0].message).to.deep.equal('boo');
```