### PR TITLE
test: fix ut for node20 json.parse improvements

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn build && yarn test --forbid-only
+yarn build && yarn test -- --forbid-only

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn build && yarn test
+yarn build && yarn test --forbid-only

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn build && yarn test -- --forbid-only
+yarn build && yarn test --forbid-only

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@salesforce/ts-types": "^2.0.3",
-    "tslib": "^2.5.2"
+    "tslib": "^2.6.0"
   },
   "devDependencies": {
     "@salesforce/dev-config": "^4.0.1",
@@ -50,7 +50,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.1",
     "husky": "^7.0.4",
     "lodash-cli": "^4.17.5",
-    "mocha": "^9.1.3",
+    "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "prettier": "^2.8.8",
     "pretty-quick": "^3.1.0",

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -50,7 +50,7 @@ describe('JsonParseError', () => {
     }
   });
 
-  it('should create with error parsing {', () => {
+  it.only('should create with error parsing {', () => {
     const nodeVersion = parseInt(versions.node.split('.')[0], 10);
     const data = '{';
     try {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -50,7 +50,7 @@ describe('JsonParseError', () => {
     }
   });
 
-  it.only('should create with error parsing {', () => {
+  it('should create with error parsing {', () => {
     const nodeVersion = parseInt(versions.node.split('.')[0], 10);
     const data = '{';
     try {

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { versions } from 'process';
 import { expect } from 'chai';
 import { JsonParseError, NamedError } from '../src/errors';
 
@@ -49,7 +50,8 @@ describe('JsonParseError', () => {
     }
   });
 
-  it('should create with error parsing {', () => {
+  it.only('should create with error parsing {', () => {
+    const nodeVersion = parseInt(versions.node.split('.')[0], 10);
     const data = '{';
     try {
       JSON.parse(data);
@@ -59,9 +61,18 @@ describe('JsonParseError', () => {
       expect(jsonErr.cause).to.equal(err);
       expect(jsonErr.name).to.equal('JsonParseError');
       expect(jsonErr.path).to.equal('fake.json');
-      expect(jsonErr.line).to.be.undefined;
-      expect(jsonErr.errorPortion).to.be.undefined;
-      expect(jsonErr.message).to.equal('Unexpected end of JSON input');
+
+      if (nodeVersion >= 20) {
+        expect(jsonErr.line).to.equal(1);
+        expect(jsonErr.errorPortion).to.equal(data);
+        expect(jsonErr.message).to.contain('Parse error in file fake.json on line 1');
+        expect(jsonErr.message).to.contain(data);
+      } else {
+        expect(jsonErr.line).to.be.undefined;
+        expect(jsonErr.errorPortion).to.be.undefined;
+
+        expect(jsonErr.message).to.equal('Unexpected end of JSON input');
+      }
     }
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1194,18 +1194,18 @@ debug@4.3.3:
   dependencies:
     ms "2.1.2"
 
-debug@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
+  dependencies:
+    ms "^2.1.1"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -2532,6 +2532,13 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2558,6 +2565,33 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+mocha@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+  dependencies:
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.3"
+    debug "4.3.4"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.2.0"
+    he "1.2.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "5.0.1"
+    ms "2.1.3"
+    nanoid "3.3.3"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    workerpool "6.2.1"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
 
 mocha@^9.1.3:
   version "9.2.2"
@@ -2615,6 +2649,11 @@ nanoid@3.3.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -3377,10 +3416,10 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
 
-tslib@^2.5.2, tslib@^2.5.3:
-  version "2.5.3"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
-  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
+tslib@^2.5.3, tslib@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -3571,6 +3610,11 @@ workerpool@6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
   integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
+
+workerpool@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
+  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
JSON.parse got smarter on newer node versions.  That caused some of our assertions to fail.

bigger picture, maybe we don't need jsonParse function and all of its fancy error constructors one 20 is the minimum.

18.15
```
> JSON.parse('{')
Uncaught SyntaxError: Unexpected end of JSON input
```
20
```
> JSON.parse('{')
Uncaught SyntaxError: Expected property name or '}' in JSON at position 1
```

fix https://github.com/forcedotcom/kit/actions/runs/5365984239/jobs/9735145421