### PR TITLE
feat!: remove cloneJson

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -86,12 +86,6 @@ export class JsonParseError extends NamedError {
   }
 }
 
-export class JsonStringifyError extends NamedError {
-  public constructor(cause: Error) {
-    super('JsonStringifyError', cause);
-  }
-}
-
 export class JsonDataFormatError extends NamedError {
   public constructor(message: string) {
     super('JsonDataFormatError', message);

--- a/src/json.ts
+++ b/src/json.ts
@@ -15,7 +15,7 @@ import {
   JsonMap,
   Optional,
 } from '@salesforce/ts-types';
-import { JsonDataFormatError, JsonParseError, JsonStringifyError } from './errors';
+import { JsonDataFormatError, JsonParseError } from './errors';
 
 /**
  * Parse JSON `string` data.
@@ -75,27 +75,6 @@ export function parseJsonMap<T extends JsonMap = JsonMap>(data: string, jsonPath
     throw new JsonDataFormatError('Expected parsed JSON data to be an object');
   }
   return json as T; // apply the requested type assertion
-}
-
-/**
- * Perform a deep clone of an object or array compatible with JSON stringification.
- * Object fields that are not compatible with stringification will be omitted. Array
- * entries that are not compatible with stringification will be censored as `null`.
- *
- * @param obj A JSON-compatible object or array to clone.
- * @throws {@link JsonStringifyError} If the object contains circular references or causes
- * other JSON stringification errors.
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export function cloneJson<T extends object>(obj: T): T {
-  try {
-    return JSON.parse(JSON.stringify(obj)) as T;
-  } catch (err) {
-    if (err instanceof SyntaxError || err instanceof TypeError) {
-      throw new JsonStringifyError(err);
-    }
-    throw err;
-  }
 }
 
 /**

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Dictionary, JsonMap } from '@salesforce/ts-types';
+import { JsonMap } from '@salesforce/ts-types';
 import { expect } from 'chai';
-import { JsonDataFormatError, JsonParseError, JsonStringifyError } from '../src/errors';
+import { JsonDataFormatError, JsonParseError } from '../src/errors';
 import * as json from '../src/json';
 
 describe('json', () => {
@@ -50,28 +50,6 @@ describe('json', () => {
 
     it('fails to parse a valid json array', () => {
       expect(() => json.parseJsonMap('[{},{}]')).to.throw(JsonDataFormatError);
-    });
-  });
-
-  describe('cloneJson', () => {
-    it('clones a valid json map', () => {
-      const o = { a: 'a', b: ['b'] };
-      const clone = json.cloneJson(o);
-      expect(clone).to.deep.equal(o);
-      expect(clone).to.not.equal(o);
-    });
-
-    it('clones a valid json array', () => {
-      const a = [{ a: 'a', b: ['b'] }, ['c', 1, true]];
-      const clone = json.cloneJson(a);
-      expect(clone).to.deep.equal(a);
-      expect(clone).to.not.equal(a);
-    });
-
-    it('fails to clone an object with circular references', () => {
-      const o: Dictionary = {};
-      o.o = o;
-      expect(() => json.cloneJson(o)).to.throw(JsonStringifyError);
     });
   });
 


### PR DESCRIPTION
@W-14726723@

breaking because removes the exported cloneJson function.  Other PRs switch from this to the native structuredClone fn