### PR TITLE
feat: logFn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,4 @@ export * from './nodash';
 export * from './collections';
 export * from './throttledPromiseAll';
 export * from './settleAll';
+export { logFn } from './log';

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export const logFn = <T>(x: T): T => {
+  // eslint-disable-next-line no-console
+  console.log(typeof x === 'string' ? x : JSON.stringify(x, null, 2));
+  return x;
+};

--- a/src/log.ts
+++ b/src/log.ts
@@ -5,8 +5,19 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+/**
+ * A wrapper for console.log that returns the input value unmodified
+ *
+ * ``` ts
+ * // peek inside a chain of map functions
+ * [1,2,3,4,5].map(logFn).map(yourNextFunction)
+ *
+ * // wrap a returned function call to see what it returns
+ * return logFn(otherFunction())
+ * ```
+ */
 export const logFn = <T>(x: T): T => {
   // eslint-disable-next-line no-console
-  console.log(typeof x === 'string' ? x : JSON.stringify(x, null, 2));
+  console.log(typeof x === 'object' ? JSON.stringify(x, null, 2) : x);
   return x;
 };


### PR DESCRIPTION
handy fn to `console.log` things without having to assign them values and writing `console.log`

[skip-validate-pr]