### PR TITLE
fix: map/set logging

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -18,6 +18,6 @@
  */
 export const logFn = <T>(x: T): T => {
   // eslint-disable-next-line no-console
-  console.log(typeof x === 'object' ? JSON.stringify(x, null, 2) : x);
+  console.log(typeof x === 'object' && !(x instanceof Set) && !(x instanceof Map) ? JSON.stringify(x, null, 2) : x);
   return x;
 };


### PR DESCRIPTION
JSON.stringify of Map/Set produce {}
we want to stringify "object" generally, but not those 2 cases (possibly more, haven't seen those yet)

note: isPlainObject from ts-types also returns true for Map/Set and didn't help